### PR TITLE
Add support for ndata in GraphShardManager

### DIFF
--- a/docs/source/shards.rst
+++ b/docs/source/shards.rst
@@ -14,7 +14,7 @@ In the distributed implementation of the sequential backward pass in  ``update_a
 
 Limitations of the distributed graph objects
 ------------------------------------------------------------------------------------
-Keep in mind that the distributed graph class :class:`sar.core.GraphShardManager` does not implement all the functionality of DGL's native graph class. For example, it does not impelement the ``successors`` and ``predecessors`` methods. It supports primarily the methods of DGL's native graphs that are relevant to GNNs such as ``update_all``, ``apply_edges``, and ``local_scope``.  It also supports setting graph node and edge features through the dictionaries ``srcdata``, ``dstdata``, and ``edata``. Note that :class:`sar.core.GraphShardManager` does not support the ``ndata`` member dictionary.
+Keep in mind that the distributed graph class :class:`sar.core.GraphShardManager` does not implement all the functionality of DGL's native graph class. For example, it does not impelement the ``successors`` and ``predecessors`` methods. It supports primarily the methods of DGL's native graphs that are relevant to GNNs such as ``update_all``, ``apply_edges``, and ``local_scope``.  It also supports setting graph node and edge features through the dictionaries ``srcdata``, ``dstdata``, and ``edata``. To remain compatible with DGLGraph :class:`sar.core.GraphShardManager` provides also access to the ``ndata`` member, which works as alias to ``srcdata``, however it is not accessible when working with MFGs.
 
 :class:`sar.core.GraphShardManager` also supports the ``in_degrees`` and ``out_degrees`` members and supports querying the number of nodes and edges in the graph. 
 


### PR DESCRIPTION
Support for ndata is required as it is used by some layers from DGL - e.g. [APPNPConv](https://github.com/dmlc/dgl/blob/b35f15b7f176277255608236400dc0a58f5b2480/python/dgl/nn/pytorch/conv/appnpconv.py#L110)

This PR should be merged after: https://github.com/IntelLabs/SAR/pull/8
