### PR TITLE
Update Python version in Github Actions

### DIFF
--- a/.github/workflows/sar_test.yaml
+++ b/.github/workflows/sar_test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Install requirements
         run: |


### PR DESCRIPTION
Fix for following CI issue:
```
Installed /opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/torch-2.0.1-py3.8-linux-x86_64.egg
Searching for numpy>=1.22.0
Reading https://pypi.org/simple/numpy/
Downloading https://files.pythonhosted.org/packages/d0/b2/fe774844d1857804cc884bba67bec38f649c99d0dc1ee7cbbf1da601357c/numpy-1.25.0.tar.gz#sha256=f1accae9a28dc3cda46a91de86acf69de0d1b5f4edd44a9b0c3ceb8036dfff19
Best match: numpy 1.25.0
Processing numpy-1.25.0.tar.gz
Writing /tmp/easy_install-d8e2z2qs/numpy-1.25.0/setup.cfg
Running numpy-1.25.0/setup.py -q bdist_egg --dist-dir /tmp/easy_install-d8e2z2qs/numpy-1.25.0/egg-dist-tmp-elt63n06
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/setuptools/sandbox.py", line [152](https://github.com/IntelLabs/SAR/actions/runs/5454348379/jobs/9924344873?pr=13#step:4:153), in save_modules
    yield saved
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/setuptools/sandbox.py", line 193, in setup_context
    yield
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/setuptools/sandbox.py", line 254, in run_setup
    _execfile(setup_script, ns)
  File "/opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages/setuptools/sandbox.py", line 43, in _execfile
    exec(code, globals, locals)
  File "/tmp/easy_install-d8e2z2qs/numpy-1.25.0/setup.py", line 22, in <module>
RuntimeError: Python version >= 3.9 required.
```