### PR TITLE
Testing comm.py

### DIFF
--- a/tests/base_utils.py
+++ b/tests/base_utils.py
@@ -1,0 +1,65 @@
+
+import os
+import sar
+import torch
+import torch.distributed as dist
+import dgl
+
+
+def initialize_worker(rank, world_size, tmp_dir):
+    """
+    Boilerplate code for setting up connection between workers
+    
+    :param rank: Rank of the current machine
+    :type rank: int
+    :param world_size: Number of workers. The same as the number of graph partitions
+    :type world_size: int
+    :param tmp_dir: Path to the directory where ip file will be created
+    :type tmp_dir: str
+    """
+    torch.seed()
+    ip_file = os.path.join(tmp_dir, 'ip_file')
+    master_ip_address = sar.nfs_ip_init(rank, ip_file)
+    sar.initialize_comms(rank, world_size, master_ip_address, 'ccl')
+
+
+def get_random_graph():
+    """
+    Generates small homogenous graph with features and labels
+    
+    :returns: dgl graph
+    """
+    graph = dgl.rand_graph(1000, 2500)
+    graph = dgl.add_self_loop(graph)
+    graph.ndata.clear()
+    graph.ndata['features'] = torch.rand((graph.num_nodes(), 10))
+    graph.ndata['labels'] = torch.randint(0, 10, (graph.num_nodes(),))
+    return graph
+
+
+def load_partition_data(rank, graph_name, tmp_dir):
+    """
+    Boilerplate code for loading partition data
+
+    :param rank: Rank of the current machine
+    :type rank: int
+    :param graph_name: Name of the partitioned graph
+    :type graph_name: str
+    :param tmp_dir: Path to the directory where partition data is located
+    :type tmp_dir: str
+    :returns: Tuple consisting of GraphShardManager object, partition features and labels
+    """
+    partition_file = os.path.join(tmp_dir, f'{graph_name}.json')
+    partition_data = sar.load_dgl_partition_data(partition_file, rank, "cpu")
+    full_graph_manager = sar.construct_full_graph(partition_data).to('cpu')
+    features = sar.suffix_key_lookup(partition_data.node_features, 'features')
+    labels = sar.suffix_key_lookup(partition_data.node_features, 'labels')
+    return full_graph_manager, features, labels
+
+
+def synchronize_processes():
+    """
+    Function that simulates dist.barrier (using all_reduce because there is an issue with dist.barrier() in ccl)
+    """
+    dummy_tensor = torch.tensor(1)
+    dist.all_reduce(dummy_tensor, dist.ReduceOp.MAX)

--- a/tests/base_utils.py
+++ b/tests/base_utils.py
@@ -1,9 +1,11 @@
-
 import os
 import sar
 import torch
 import torch.distributed as dist
 import dgl
+# IMPORTANT - This module should be imported independently
+# only by the child processes - i.e. separate workers
+ 
 
 
 def initialize_worker(rank, world_size, tmp_dir):

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,7 +3,7 @@ import torch.nn.functional as F
 from torch import nn
 
 class GNNModel(nn.Module):
-    def __init__(self,  in_dim: int, hidden_dim: int, out_dim: int):
+    def __init__(self,  in_dim: int, out_dim: int):
         super().__init__()
 
         self.convs = nn.ModuleList([

--- a/tests/multiprocessing_utils.py
+++ b/tests/multiprocessing_utils.py
@@ -1,15 +1,52 @@
-
 import multiprocessing as mp
 import traceback
 import pytest
 import functools
+import tempfile
+
 
 def handle_mp_exception(mp_dict):
+    """
+    Used to handle exceptions that occurred in child processes
+    
+    :param mp_dict: Dictionary that is shared between different processes
+    :type mp_dict: multiprocessing.managers.DictProxy
+    """
     msg = mp_dict.get('traceback', "")
     for e_arg in mp_dict['exception'].args:
         msg += str(e_arg)
     print(str(msg), flush=True)
     pytest.fail(str(msg), pytrace=False)
+
+
+def run_workers(func, world_size):
+    """
+    Starts `world_size` number of processes, where each of them
+    behaves as a separate worker and invokes function specified 
+    by the parameter.
+    
+    :param func: The function that will be invoked by each process
+    :type func: function
+    :returns: mp_dict which can be used by workers to return
+    results from `func`
+    """
+    manager = mp.Manager()
+    mp_dict = manager.dict()
+    processes = []
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        for rank in range(1, world_size):
+            p = mp.Process(target=func, args=(mp_dict, rank, world_size, tmp_dir))
+            p.daemon = True
+            p.start()
+            processes.append(p)
+        func(mp_dict, 0, world_size, tmp_dir)
+            
+        for p in processes:
+            p.join()
+        if 'exception' in mp_dict:
+            handle_mp_exception(mp_dict)
+    return mp_dict
+
     
 def sar_test(func):
     """

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -1,0 +1,79 @@
+from copy import deepcopy
+import traceback
+from multiprocessing_utils import *
+# Do not import DGL and SAR - these modules should be
+# independently loaded inside each process
+
+
+@pytest.mark.parametrize('world_size', [2, 4, 8])
+@sar_test
+def test_sync_params(world_size):
+    """
+    Checks whether model's parameters are the same across all
+    workers after calling sync_params function. Parameters of worker 0
+    should be copied to all workers, so its parameters before and after
+    sync_params should be the same
+    """
+    import torch
+    def sync_params(mp_dict, rank, world_size, tmp_dir):
+        import sar
+        from tests.base_utils import initialize_worker
+        from models import GNNModel
+        try:
+            initialize_worker(rank, world_size, tmp_dir)
+            model = GNNModel(16, 4)
+            if rank == 0:   
+                mp_dict[f"result_{rank}"] = deepcopy(model.state_dict())
+            sar.sync_params(model)
+            if rank != 0:
+                mp_dict[f"result_{rank}"] = model.state_dict()
+        except Exception as e: 
+            mp_dict["traceback"] = str(traceback.format_exc())
+            mp_dict["exception"] = e
+        
+    mp_dict = run_workers(sync_params, world_size)
+    for rank in range(1, world_size):
+        for key in mp_dict[f"result_0"].keys():
+            assert torch.all(torch.eq(mp_dict[f"result_0"][key], mp_dict[f"result_{rank}"][key]))
+        
+    
+@pytest.mark.parametrize('world_size', [2, 4, 8])
+@sar_test
+def test_gather_grads(world_size):
+    """
+    Checks whether parameter's gradients are the same across all
+    workers after calling gather_grads function 
+    """
+    import torch
+    def gather_grads(mp_dict, rank, world_size, tmp_dir):
+        import sar
+        import dgl
+        import torch.nn.functional as F
+        from models import GNNModel
+        from base_utils import initialize_worker, get_random_graph, synchronize_processes,\
+            load_partition_data
+        try:
+            initialize_worker(rank, world_size, tmp_dir)
+            graph_name = 'dummy_graph'
+            if rank == 0:
+                g = get_random_graph()
+                dgl.distributed.partition_graph(g, graph_name, world_size,
+                                        tmp_dir, num_hops=1,
+                                        balance_edges=True)
+            synchronize_processes()
+            fgm, feat, labels = load_partition_data(rank, graph_name, tmp_dir)
+            model = GNNModel(feat.shape[1], labels.max()+1)
+            sar.sync_params(model)
+            sar_logits = model(fgm, feat)
+            sar_loss = F.cross_entropy(sar_logits, labels)
+            sar_loss.backward()
+            sar.gather_grads(model)
+            mp_dict[f"result_{rank}"] = [torch.tensor(x.grad) for x in model.parameters()]
+        except Exception as e: 
+            mp_dict["traceback"] = str(traceback.format_exc())
+            mp_dict["exception"] = e
+        
+    mp_dict = run_workers(gather_grads, world_size)
+    for rank in range(1, world_size):
+        for i in range(len(mp_dict["result_0"])):
+            assert torch.all(torch.eq(mp_dict["result_0"][i], mp_dict[f"result_{rank}"][i]))

--- a/tests/test_patch_dgl.py
+++ b/tests/test_patch_dgl.py
@@ -1,6 +1,7 @@
-from utils import *
+from multiprocessing_utils import *
 # Do not import DGL and SAR - these modules should be
 # independently loaded inside each process
+
 
 @sar_test
 def test_patch_dgl():

--- a/tests/test_sar.py
+++ b/tests/test_sar.py
@@ -1,10 +1,11 @@
-from utils import *
+from multiprocessing_utils import *
 import os
 import tempfile
-
+import traceback
 import numpy as np
 # Do not import DGL and SAR - these modules should be
 # independently loaded inside each process
+
 
 def sar_process(mp_dict, rank, world_size, tmp_dir):
     """
@@ -53,7 +54,7 @@ def sar_process(mp_dict, rank, world_size, tmp_dir):
         features = sar.suffix_key_lookup(partition_data.node_features, 'features')
         del partition_data
 
-        model = GNNModel(features.size(1), 32, features.size(1)).to('cpu')
+        model = GNNModel(features.size(1), features.size(1)).to('cpu')
         sar.sync_params(model)
 
         logits = model(full_graph_manager, features)


### PR DESCRIPTION
- Two new tests for comm.py file - sync_params and gather_grads
- Moving frequently used functions during tests to another file
- Splitting utils to multiprocessing_utils and base_utils to avoid unnecessary imports in parent processes (which causes tests to fail)