### PR TITLE
Fix pytest rtol error

### DIFF
--- a/tests/test_sar.py
+++ b/tests/test_sar.py
@@ -114,7 +114,7 @@ def test_sar_full_graph(world_size):
 
         sar_logits_mean = sar_logits.mean()
 
-        rtol = sar_logits_mean / 1000
+        rtol = abs(sar_logits_mean) / 1000
         assert full_graph_mean == pytest.approx(sar_logits_mean, rtol)
 
 @sar_test


### PR DESCRIPTION
RTOL value can't be negative
Encountered in following test run: https://github.com/IntelLabs/SAR/actions/runs/5521373186/jobs/10069372336?pr=14