### PR TITLE
Update initialization docs

### DIFF
--- a/docs/source/comm.rst
+++ b/docs/source/comm.rst
@@ -16,12 +16,12 @@ In an environment with a networked file system, initializing ``torch.distributed
       comm_device = torch.device('cuda')
   else:
       comm_device = torch.device('cpu')
-  
-  master_ip_address = sar.nfs_ip_init(rank,path_to_ip_file)
-  sar.initialize_comms(rank,world_size, master_ip_address,backend_name,comm_device)
+
+  master_ip_address = sar.nfs_ip_init(rank, path_to_ip_file)
+  sar.initialize_comms(rank, world_size, master_ip_address, backend_name, comm_device)
 
 ..
-
+:func:`sar.initialize_comms` tries to initialize the torch.distributed process group, but only if it has not been initialized. User can initialize process group on his own before calling :func:`sar.initialize_comms`.
 :func:`sar.nfs_ip_init` communicates the master's ip address to the workers through the file system. In the absence of a networked file system, you should develop your own mechanism to communicate the master's ip address.
 
 You can specify the name of the socket that will be used for communication with `SAR_SOCKET_NAME` environment variable (if not specified, the first available socket will be selected).

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -61,8 +61,8 @@ Initialize the communication through a call to :func:`sar.initialize_comms` , sp
       comm_device = torch.device('cuda')
   else:
       comm_device = torch.device('cpu')
-  master_ip_address = sar.nfs_ip_init(rank,path_to_ip_file)
-  sar.initialize_comms(rank,world_size, master_ip_address,backend_name,comm_device)
+  master_ip_address = sar.nfs_ip_init(rank, path_to_ip_file)
+  sar.initialize_comms(rank, world_size, master_ip_address, backend_name, comm_device)
   
 .. 
 

--- a/sar/comm.py
+++ b/sar/comm.py
@@ -158,9 +158,6 @@ def initialize_comms(_rank: int, _world_size: int, master_ip_address: str,
         else:
             _comm_device = torch.device('cpu')
 
-#    if is_initialized():
- #       return
-
     if backend == 'ccl':
         # pylint: disable=unused-import
         try:
@@ -195,9 +192,13 @@ def initialize_comms(_rank: int, _world_size: int, master_ip_address: str,
 
         os.environ['I_MPI_COMM_WORLD'] = str(_world_size)
         os.environ['I_MPI_COMM_RANK'] = str(_rank)
-
-        dist.init_process_group(
-             backend=backend, rank=_rank, world_size=_world_size)
+        try:
+            dist.init_process_group(
+                backend=backend, rank=_rank, world_size=_world_size)
+        except:
+            logger.error("SAR was unable to initialize torch.distributed process group. "
+                         "You can try to do it manually before calling sar.initialize_comms")
+            raise
     else:
         assert dist.get_backend() in ['ccl', 'nccl',
                        'mpi'], 'backend must be ccl, nccl, or mpi'


### PR DESCRIPTION
As in PR title. Plan was to remove process group initialization from initialize_comms function, however I think current solution is better and  user still has full flexibility in terms of distributed process group initialization.
Otherwise almost every sar functions should have check whether dist_process_group has been initialized 