### PR TITLE
GraphShardManager - handling ntype with num_src_nodes and num_dst_nodes 

### DIFF
--- a/sar/common_tuples.py
+++ b/sar/common_tuples.py
@@ -24,6 +24,7 @@ Tuples for grouping related data
 from typing import NamedTuple, Dict, Tuple, List, Optional, Any, TYPE_CHECKING
 from enum import Enum
 from torch import Tensor
+import dgl  # type: ignore
 
 if TYPE_CHECKING:
     from .core.graphshard import GraphShardManager
@@ -94,6 +95,10 @@ class PartitionData(NamedTuple):
 
         List of edge type names. Use in conjunction with dgl.ETYPE edge features to get\
     the edge type of each edge
+    
+    .. py:attribute:: partition_book : dgl.distributed.GraphPartitionBook
+    
+        The graph partition information
 
 
     '''
@@ -103,6 +108,7 @@ class PartitionData(NamedTuple):
     node_features: Dict[str, Tensor]
     node_type_names: List[str]
     edge_type_names: List[str]
+    partition_book: dgl.distributed.GraphPartitionBook
 
 
 class AggregationData(NamedTuple):

--- a/sar/construct_shard_manager.py
+++ b/sar/construct_shard_manager.py
@@ -56,6 +56,7 @@ def make_induced_graph_shard_manager(full_graph_shards: List[ShardEdgesAndFeatur
                                      seed_nodes: Tensor,
                                      node_ranges: List[Tuple[int, int]],
                                      edge_type_names: List[str],
+                                     partition_book : dgl.distributed.GraphPartitionBook,
                                      keep_seed_nodes: bool = True) -> GraphShardManager:
     '''
     Creates new graph shards that only contain edges to the seed nodes. Adjusts the target
@@ -104,7 +105,7 @@ def make_induced_graph_shard_manager(full_graph_shards: List[ShardEdgesAndFeatur
         graph_shard_list.append(GraphShard(shard_edges_features,
                                            src_range, tgt_range, edge_type_names))
 
-    return GraphShardManager(graph_shard_list, src_compact_data['local_src_seed_nodes'], seed_nodes)
+    return GraphShardManager(graph_shard_list, src_compact_data['local_src_seed_nodes'], seed_nodes, partition_book)
 
 
 def compact_src_ranges(active_edges_src, seed_nodes, node_ranges, keep_seed_nodes):
@@ -178,6 +179,7 @@ def construct_mfgs(partition_data: PartitionData,
                                                seed_nodes,
                                                partition_data.node_ranges,
                                                partition_data.edge_type_names,
+                                               partition_data.partition_book,
                                                keep_seed_nodes)
         graph_shard_manager_list.append(gsm)
         seed_nodes = gsm.input_nodes + partition_data.node_ranges[rank()][0]

--- a/sar/construct_shard_manager.py
+++ b/sar/construct_shard_manager.py
@@ -204,7 +204,7 @@ def construct_full_graph(partition_data: PartitionData) -> GraphShardManager:
     seed_nodes = torch.arange(partition_data.node_ranges[rank()][1] -
                               partition_data.node_ranges[rank()][0])
     return GraphShardManager(graph_shard_list,
-                             seed_nodes, seed_nodes)
+                             seed_nodes, seed_nodes, partition_data.partition_book)
     
 def convert_dist_graph(dist_graph: dgl.distributed.DistGraph) -> GraphShardManager:
     partition_data = load_dgl_partition_data_from_graph(dist_graph, dist_graph.device)

--- a/sar/construct_shard_manager.py
+++ b/sar/construct_shard_manager.py
@@ -56,7 +56,8 @@ def make_induced_graph_shard_manager(full_graph_shards: List[ShardEdgesAndFeatur
                                      seed_nodes: Tensor,
                                      node_ranges: List[Tuple[int, int]],
                                      edge_type_names: List[str],
-                                     partition_book : dgl.distributed.GraphPartitionBook,
+                                     partition_book: dgl.distributed.GraphPartitionBook,
+                                     node_types: Tensor,
                                      keep_seed_nodes: bool = True) -> GraphShardManager:
     '''
     Creates new graph shards that only contain edges to the seed nodes. Adjusts the target
@@ -105,7 +106,8 @@ def make_induced_graph_shard_manager(full_graph_shards: List[ShardEdgesAndFeatur
         graph_shard_list.append(GraphShard(shard_edges_features,
                                            src_range, tgt_range, edge_type_names))
 
-    return GraphShardManager(graph_shard_list, src_compact_data['local_src_seed_nodes'], seed_nodes, partition_book)
+    return GraphShardManager(graph_shard_list, src_compact_data['local_src_seed_nodes'],
+                             seed_nodes, partition_book, node_types)
 
 
 def compact_src_ranges(active_edges_src, seed_nodes, node_ranges, keep_seed_nodes):
@@ -180,6 +182,7 @@ def construct_mfgs(partition_data: PartitionData,
                                                partition_data.node_ranges,
                                                partition_data.edge_type_names,
                                                partition_data.partition_book,
+                                               partition_data.node_features[dgl.NTYPE],
                                                keep_seed_nodes)
         graph_shard_manager_list.append(gsm)
         seed_nodes = gsm.input_nodes + partition_data.node_ranges[rank()][0]
@@ -205,8 +208,8 @@ def construct_full_graph(partition_data: PartitionData) -> GraphShardManager:
                         for part_idx in range(num_splits)]
     seed_nodes = torch.arange(partition_data.node_ranges[rank()][1] -
                               partition_data.node_ranges[rank()][0])
-    return GraphShardManager(graph_shard_list,
-                             seed_nodes, seed_nodes, partition_data.partition_book)
+    return GraphShardManager(graph_shard_list, seed_nodes, seed_nodes,
+                             partition_data.partition_book, partition_data.node_features[dgl.NTYPE])
     
 def convert_dist_graph(dist_graph: dgl.distributed.DistGraph) -> GraphShardManager:
     partition_data = load_dgl_partition_data_from_graph(dist_graph, dist_graph.device)

--- a/sar/core/graphshard.py
+++ b/sar/core/graphshard.py
@@ -227,8 +227,9 @@ class GraphShardManager:
         self.in_degrees_cache: Dict[Optional[str], Tensor] = {}
         self.out_degrees_cache: Dict[Optional[str], Tensor] = {}
 
+        # passing number of nodes and edges specific for current machine not whole distributed graph
         self.srcdata = ChainedDataView(self.num_src_nodes())
-        self.edata = ChainedDataView(self.num_edges())
+        self.edata = ChainedDataView(self.partition_book.metadata()[rank()]["num_edges"])
 
         if self.src_is_tgt:
             assert self.num_src_nodes() == self.num_dst_nodes()

--- a/sar/data_loading.py
+++ b/sar/data_loading.py
@@ -136,11 +136,15 @@ def create_partition_data(graph: dgl.DGLGraph,
     # Include the node types in the node feature dictionary
     if dgl.NTYPE in graph.ndata:
         node_features[dgl.NTYPE] = graph.ndata[dgl.NTYPE][graph.ndata['inner_node'].bool()]
+    else:
+        node_features[dgl.NTYPE] = torch.zeros(graph.num_nodes())[graph.ndata['inner_node'].bool()]
 
     # Include the edge types in the edge feature dictionary
     inner_edge_mask = graph.edata['inner_edge'].bool()
     if dgl.ETYPE in graph.edata:
         edge_features[dgl.ETYPE] = graph.edata[dgl.ETYPE][inner_edge_mask]
+    else:
+        edge_features[dgl.ETYPE] = torch.zeros(graph.num_edges())[inner_edge_mask]
 
     # Obtain the inner edges. These are the partition edges
     local_partition_edges = torch.stack(graph.all_edges())[:, inner_edge_mask]

--- a/sar/data_loading.py
+++ b/sar/data_loading.py
@@ -173,7 +173,8 @@ def create_partition_data(graph: dgl.DGLGraph,
                          node_ranges,
                          node_features,
                          node_type_list,
-                         edge_type_list
+                         edge_type_list,
+                         partition_book
                          )
 
 

--- a/tests/base_utils.py
+++ b/tests/base_utils.py
@@ -39,6 +39,25 @@ def get_random_graph():
     return graph
 
 
+def get_random_hetero_graph():
+    """
+    Generates small heterogenous graph with features and labels
+    on only one of all of the node types
+    
+    :returns: dgl graph
+    """
+    graph_data = {
+        ("n_type_1", "rel_1", "n_type_2"): (torch.randint(0, 800, (40,)), torch.randint(0, 800, (40,))),
+        ("n_type_1", "rel_2", "n_type_3"): (torch.randint(0, 800, (40,)), torch.randint(0, 800, (40,))),
+        ("n_type_2", "rel_3", "n_type_3"): (torch.randint(0, 800, (40,)), torch.randint(0, 800, (40,))),
+        ("n_type_3", "rel_4", "n_type_4"): (torch.randint(0, 800, (40,)), torch.randint(0, 800, (40,)))
+    }
+    hetero_graph = dgl.heterograph(graph_data)
+    hetero_graph.nodes["n_type_1"].data["features"] = torch.rand((hetero_graph.num_nodes("n_type_1"), 10))        
+    hetero_graph.nodes["n_type_1"].data["labels"] = torch.randint(0, 10, (hetero_graph.num_nodes("n_type_1"),))
+    return hetero_graph
+
+
 def load_partition_data(rank, graph_name, tmp_dir):
     """
     Boilerplate code for loading partition data

--- a/tests/base_utils.py
+++ b/tests/base_utils.py
@@ -47,10 +47,10 @@ def get_random_hetero_graph():
     :returns: dgl graph
     """
     graph_data = {
-        ("n_type_1", "rel_1", "n_type_2"): (torch.randint(0, 800, (40,)), torch.randint(0, 800, (40,))),
-        ("n_type_1", "rel_2", "n_type_3"): (torch.randint(0, 800, (40,)), torch.randint(0, 800, (40,))),
-        ("n_type_2", "rel_3", "n_type_3"): (torch.randint(0, 800, (40,)), torch.randint(0, 800, (40,))),
-        ("n_type_3", "rel_4", "n_type_4"): (torch.randint(0, 800, (40,)), torch.randint(0, 800, (40,)))
+        ("n_type_1", "rel_1", "n_type_2"): (torch.randint(0, 800, (1000,)), torch.randint(0, 800, (1000,))),
+        ("n_type_1", "rel_2", "n_type_3"): (torch.randint(0, 800, (1000,)), torch.randint(0, 800, (1000,))),
+        ("n_type_2", "rel_3", "n_type_3"): (torch.randint(0, 800, (1000,)), torch.randint(0, 800, (1000,))),
+        ("n_type_3", "rel_4", "n_type_4"): (torch.randint(0, 800, (1000,)), torch.randint(0, 800, (1000,)))
     }
     hetero_graph = dgl.heterograph(graph_data)
     hetero_graph.nodes["n_type_1"].data["features"] = torch.rand((hetero_graph.num_nodes("n_type_1"), 10))        

--- a/tests/test_graph_shard_manager.py
+++ b/tests/test_graph_shard_manager.py
@@ -1,0 +1,94 @@
+from multiprocessing_utils import *
+# Do not import DGL and SAR - these modules should be
+# independently loaded inside each process
+
+@pytest.mark.parametrize("backend", ["ccl", "gloo"])
+@pytest.mark.parametrize("world_size", [2, 4, 8])
+@sar_test
+def test_graph_properties_heterogenousgraph(world_size, backend):
+    import numpy as np
+    def graph_properties(mp_dict, rank, world_size, tmp_dir, **kwargs):
+        import dgl
+        from base_utils import initialize_worker, get_random_hetero_graph,\
+            synchronize_processes, load_partition_data
+        try:
+            initialize_worker(rank, world_size, tmp_dir, backend=kwargs["backend"])
+            graph_name = 'dummy_graph'
+            if rank == 0:
+                g = get_random_hetero_graph()
+                mp_dict["expected_num_nodes"] = g.num_nodes()
+                mp_dict["expected_num_edges"] = g.num_edges()
+                mp_dict["expected_num_node_types"] = [g.num_nodes(type) for type in g.ntypes]
+                mp_dict["expected_ntypes"] = g.ntypes
+                mp_dict["expected_etypes"] = g.etypes
+                mp_dict["expected_canonical_etypes"] = g.canonical_etypes
+                dgl.distributed.partition_graph(g, graph_name, world_size,
+                                        tmp_dir, num_hops=1,
+                                        balance_edges=True)
+            synchronize_processes()
+            fgm, _, _ = load_partition_data(rank, graph_name, tmp_dir)
+            mp_dict[f"result_{rank}_num_nodes"] = fgm.num_nodes()
+            mp_dict[f"result_{rank}_num_edges"] = fgm.num_edges()
+            mp_dict[f"result_{rank}_num_node_types"] = [fgm.num_nodes(type) for type in fgm.ntypes]
+            mp_dict[f"result_{rank}_ntypes"] = fgm.ntypes
+            mp_dict[f"result_{rank}_etypes"] = fgm.etypes
+            mp_dict[f"result_{rank}_canonical_etypes"] = fgm.canonical_etypes            
+        except Exception as e: 
+            mp_dict["traceback"] = str(traceback.format_exc())
+            mp_dict["exception"] = e
+            
+    mp_dict = run_workers(graph_properties, world_size=world_size, backend=backend)
+    
+    assert mp_dict["expected_num_nodes"] == sum([mp_dict[f"result_{rank}_num_nodes"] for rank in range(world_size)]) / world_size, "Number of nodes does not match"
+    assert mp_dict["expected_num_edges"] == sum([mp_dict[f"result_{rank}_num_edges"] for rank in range(world_size)]) / world_size, "Number of edges does not match"
+    assert all(np.array(mp_dict["expected_num_node_types"]) == sum([np.array(mp_dict[f"result_{rank}_num_node_types"]) for rank in range(world_size)]) / world_size), "Number of nodes for specific types does not match"
+    for rank in range(world_size):
+        assert all(x == y for x, y in zip(mp_dict["expected_ntypes"], mp_dict[f"result_{rank}_ntypes"]) ), "Node types does not match"
+        assert all(x == y for x, y in zip(mp_dict["expected_etypes"], mp_dict[f"result_{rank}_etypes"])), "Edge types does not match"
+        assert all(x == y for x, y in zip(mp_dict["expected_canonical_etypes"], mp_dict[f"result_{rank}_canonical_etypes"])), "Canonical edge does not match"
+
+
+@pytest.mark.parametrize("backend", ["ccl", "gloo"])
+@pytest.mark.parametrize("world_size", [2, 4, 8])
+@sar_test
+def test_graph_properties_homogenousgraph(world_size, backend):
+    import numpy as np
+    def graph_properties(mp_dict, rank, world_size, tmp_dir, **kwargs):
+        import dgl
+        from base_utils import initialize_worker, get_random_graph,\
+            synchronize_processes, load_partition_data
+        try:
+            initialize_worker(rank, world_size, tmp_dir, backend=kwargs["backend"])
+            graph_name = 'dummy_graph'
+            if rank == 0:
+                g = get_random_graph()
+                mp_dict["expected_num_nodes"] = g.num_nodes()
+                mp_dict["expected_num_edges"] = g.num_edges()
+                mp_dict["expected_num_node_types"] = [g.num_nodes(type) for type in g.ntypes]
+                mp_dict["expected_ntypes"] = g.ntypes
+                mp_dict["expected_etypes"] = g.etypes
+                mp_dict["expected_canonical_etypes"] = g.canonical_etypes
+                dgl.distributed.partition_graph(g, graph_name, world_size,
+                                        tmp_dir, num_hops=1,
+                                        balance_edges=True)
+            synchronize_processes()
+            fgm, _, _ = load_partition_data(rank, graph_name, tmp_dir)
+            mp_dict[f"result_{rank}_num_nodes"] = fgm.num_nodes()
+            mp_dict[f"result_{rank}_num_edges"] = fgm.num_edges()
+            mp_dict[f"result_{rank}_num_node_types"] = [fgm.num_nodes(type) for type in fgm.ntypes]
+            mp_dict[f"result_{rank}_ntypes"] = fgm.ntypes
+            mp_dict[f"result_{rank}_etypes"] = fgm.etypes
+            mp_dict[f"result_{rank}_canonical_etypes"] = fgm.canonical_etypes            
+        except Exception as e: 
+            mp_dict["traceback"] = str(traceback.format_exc())
+            mp_dict["exception"] = e
+            
+    mp_dict = run_workers(graph_properties, world_size=world_size, backend=backend)
+    
+    assert mp_dict["expected_num_nodes"] == sum([mp_dict[f"result_{rank}_num_nodes"] for rank in range(world_size)]) / world_size, "Number of nodes does not match"
+    assert mp_dict["expected_num_edges"] == sum([mp_dict[f"result_{rank}_num_edges"] for rank in range(world_size)]) / world_size, "Number of edges does not match"
+    assert all(np.array(mp_dict["expected_num_node_types"]) == sum([np.array(mp_dict[f"result_{rank}_num_node_types"]) for rank in range(world_size)]) / world_size), "Number of nodes for specific types does not match"
+    for rank in range(world_size):
+        assert all(x == y for x, y in zip(mp_dict["expected_ntypes"], mp_dict[f"result_{rank}_ntypes"]) ), "Node types does not match"
+        assert all(x == y for x, y in zip(mp_dict["expected_etypes"], mp_dict[f"result_{rank}_etypes"])), "Edge types does not match"
+        assert all(x == y for x, y in zip(mp_dict["expected_canonical_etypes"], mp_dict[f"result_{rank}_canonical_etypes"])), "Canonical edge does not match"


### PR DESCRIPTION
In this PR I've added two functions to the GraphShardManager API: `dsttypes` and `srctypes` compatible with DGL API (https://docs.dgl.ai/en/0.8.x/generated/dgl.DGLGraph.srctypes.html?highlight=srctypes, https://docs.dgl.ai/en/0.8.x/generated/dgl.DGLGraph.dsttypes.html?highlight=dsttypes).
Also, from now functions `num_src_nodes` and `num_dst_nodes` accept ntype parameter.

This PR needs to be merged after #22 (only "2fdd749" commit is relevant)